### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
     keywords='invenio news',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-news',
     packages=[
         'invenio_news',


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
